### PR TITLE
✨ feat: 工作流中分离构建与发布

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Flutter Build
+name: 1.Flutter Build
 
 on: workflow_dispatch
 permissions: write-all
@@ -85,12 +85,6 @@ jobs:
           restore-keys: |
             build-apk
 
-      - name: Publish Android Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: SITLife-Android-release
-          path: build/app/outputs/flutter-apk/publish/1-SITLife-release-signed.apk
-
   build_ios:
     runs-on: macos-latest
 
@@ -173,36 +167,20 @@ jobs:
         mkdir -p build-output/ios/publish/
         mv build-output/ios/life.mysit.SITLife.ipa build-output/ios/publish/2-SITLife-release.ipa
 
-    # Debug only
-    # - name: (Debug) Publish ipa file
+    # - name: Publish ipa file
     #   run: |
     #     touch build-output/ios/publish/.release
 
-    # - name: (Debug) Cache ipa
-    #   id: cache-ipa
-    #   uses: actions/cache@v4
-    #   with:
-    #     path: |
-    #       build-output/ios/
-    #     key: build-ipa
-    #     enableCrossOsArchive: true
-    #     restore-keys: |
-    #       build-ipa
-
-    # - name: (Debug) Publish iOS Artifact
-    #   uses: actions/upload-artifact@v4
-    #   with:
-    #     name: SITLife-iOS-release
-    #     path: build-output/ios/publish/2-SITLife-release.ipa
-
-    # Release
-    - name: Deploy to App Store (Testflight)
-      uses: apple-actions/upload-testflight-build@v1
+    - name: Cache ipa
+      id: cache-ipa
+      uses: actions/cache@v4
       with:
-        app-path: ${{ github.workspace }}/build-output/ios/publish/2-SITLife-release.ipa
-        issuer-id: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
-        api-key-id: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
-        api-private-key: ${{ secrets.APP_STORE_CONNECT_API_PRIVATE_KEY }}
+        path: |
+          build-output/ios/
+        key: build-ipa
+        enableCrossOsArchive: true
+        restore-keys: |
+          build-ipa
 
   after_build:
     runs-on: ubuntu-latest
@@ -223,7 +201,6 @@ jobs:
         run: |
           git fetch --tags
           echo "RESOLVED_VERSION="$(git tag --sort=-v:refname | head -n 1) >> "$GITHUB_OUTPUT"
-          echo "PREVIOUS_TAG="$(git tag --sort=-v:refname | head -n 2 | tail -n 1) >> "$GITHUB_OUTPUT"
 
       - name: Restore cache builds (apk)
         id: cache-apk
@@ -248,24 +225,19 @@ jobs:
         env:
           RESOLVED_VERSION: ${{ steps.get_git_info.outputs.RESOLVED_VERSION }}
         run: |
-          if [ -f "build/app/outputs/flutter-apk/publish/1-SITLife-release-signed.apk" ]; then
-            mv build/app/outputs/flutter-apk/publish/1-SITLife-release-signed.apk build/app/outputs/flutter-apk/publish/SITLife-${{ env.RESOLVED_VERSION }}.apk
-          fi
-          if [ -f "build-output/ios/publish/2-SITLife-release.ipa" ]; then
-            mv build-output/ios/publish/2-SITLife-release.ipa build-output/ios/publish/SITLife-${{ env.RESOLVED_VERSION }}.ipa
-          fi
-
           if [ ! -f "build/app/outputs/flutter-apk/publish/.release" ]; then
-            rm -rf build/app/outputs/flutter-apk/publish/SITLife-${{ env.RESOLVED_VERSION }}.apk
-            echo "APK_SHA256=" >> "$GITHUB_OUTPUT"
-          else
-            echo "APK_SHA256=- \`SITLife-${{ env.RESOLVED_VERSION }}.apk\`: "$(sha256sum build/app/outputs/flutter-apk/publish/SITLife-${{ env.RESOLVED_VERSION }}.apk | awk '{print $1}') >> "$GITHUB_OUTPUT"
+            rm -rf build/app/outputs/flutter-apk/publish/1-SITLife-release-signed.apk
           fi
           if [ ! -f "build-output/ios/publish/.release" ]; then
-            rm -rf build-output/ios/publish/SITLife-${{ env.RESOLVED_VERSION }}.ipa
-            echo "IPA_SHA256=" >> "$GITHUB_OUTPUT"
-          else
-            echo "IPA_SHA256=- \`SITLife-${{ env.RESOLVED_VERSION }}.ipa\`: "$(sha256sum build-output/ios/publish/SITLife-${{ env.RESOLVED_VERSION }}.ipa | awk '{print $1}') >> "$GITHUB_OUTPUT"
+            rm -rf build-output/ios/publish/2-SITLife-release.ipa
+          fi
+
+          mkdir build/upload-artifacts/
+          if [ -f "build/app/outputs/flutter-apk/publish/1-SITLife-release-signed.apk" ]; then
+            mv build/app/outputs/flutter-apk/publish/1-SITLife-release-signed.apk build/upload-artifacts/SITLife-${{ env.RESOLVED_VERSION }}.apk
+          fi
+          if [ -f "build-output/ios/publish/2-SITLife-release.ipa" ]; then
+            mv build-output/ios/publish/2-SITLife-release.ipa build/upload-artifacts/SITLife-${{ env.RESOLVED_VERSION }}.ipa
           fi
 
       - name: Push changes
@@ -273,49 +245,28 @@ jobs:
         with:
           branch: ${{ github.ref }}
 
-      - name: Release
-        uses: softprops/action-gh-release@v2
-        env:
-            RESOLVED_VERSION: ${{ steps.get_git_info.outputs.RESOLVED_VERSION }}
-            PREVIOUS_TAG: ${{ steps.get_git_info.outputs.PREVIOUS_TAG }}
+      # Android
+      - name: Publish Android Artifact
+        uses: actions/upload-artifact@v4
         with:
-          files: |
-            build/app/outputs/flutter-apk/publish/SITLife-${{ env.RESOLVED_VERSION }}.apk
-            build-output/ios/publish/SITLife-${{ env.RESOLVED_VERSION }}.ipa
-          tag_name: ${{ env.RESOLVED_VERSION }}
-          body: |
-              ## Changes
-              ### Features
-                - Foo
-              ### Bug fixes
-                - Bar
+          name: SITLife-Android-release
+          path: build/upload-artifacts/SITLife-${{ steps.get_git_info.outputs.RESOLVED_VERSION }}.apk
 
-              ## 更改
-              ### 新功能
-                - Foo
-              ### Bug 修复
-                - Bar
+      # iOS
+      - name: Publish iOS Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SITLife-iOS-release
+          path: build/upload-artifacts/SITLife-${{ steps.get_git_info.outputs.RESOLVED_VERSION }}.ipa
 
-              ## How to download
-                <!-- Android:main -->
-                <!-- - `Android`: Click the .apk files below.-->
-                <!-- iOS:main -->
-                <!-- - `iOS`: [Download on the App Store](https://apps.apple.com/cn/app/id6468989112).-->
-                <!-- iOS:TestFlight -->
-                <!-- - `iOS`: [Join the Test Flight](https://testflight.apple.com/join/ecafeulK).-->
-                <!-- iOS:Debug -->
-                <!-- - `iOS`: Click the .ipa files below.-->
-
-                - `Android`: Click the .apk files below.
-                - `iOS`: [Join the Test Flight](https://testflight.apple.com/join/ecafeulK).
-
-              ## Checksum (sha256)
-              ${{ steps.builds.outputs.APK_SHA256 }}
-              ${{ steps.builds.outputs.IPA_SHA256 }}
-
-              Full Changelog: https://github.com/${{ github.repository }}/compare/${{ env.PREVIOUS_TAG }}...${{ env.RESOLVED_VERSION }}
-          draft: true
-          prerelease: false
+      - name: Deploy to App Store (TestFlight)
+        if: github.repository == 'liplum-dev/mimir'
+        uses: apple-actions/upload-testflight-build@v1
+        with:
+          app-path: ${{ github.workspace }}/build-output/ios/publish/SITLife-${{ steps.get_git_info.outputs.RESOLVED_VERSION }}.ipa
+          issuer-id: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          api-key-id: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          api-private-key: ${{ secrets.APP_STORE_CONNECT_API_PRIVATE_KEY }}
 
       - name: Delete cache builds (apk)
         if: steps.cache-apk.outputs.cache-hit == 'true'

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -1,0 +1,92 @@
+name: 2.Draft New Release
+
+on: workflow_dispatch
+
+jobs:
+  draft-new-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get Flutter Build Run ID
+        id: get_run_id
+        run: |
+          echo "run_id="$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/actions/workflows/build.yml/runs | jq -r '.workflow_runs[0].id') >> "$GITHUB_OUTPUT"
+      
+      - name: Download artifacts
+        run: |
+          mkdir new-build-artifacts
+          cd new-build-artifacts
+          curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -L https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ steps.get_run_id.outputs.run_id }}/artifacts | jq -r '.artifacts[].archive_download_url' | xargs -n 1 curl -LJO -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}"
+          echo $(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -L https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ steps.get_run_id.outputs.run_id }}/artifacts | jq -r '.artifacts[].archive_download_url')
+          cd ..
+          ls -l new-build-artifacts
+
+      - name: Unzip artifacts
+        run: |
+          unzip -o 'new-build-artifacts/*.zip' -d new-build-artifacts
+          ls -l new-build-artifacts
+
+      - name: Get Git info
+        id: get_git_info
+        run: |
+          echo "RESOLVED_VERSION="$(ls new-build-artifacts | grep -oP 'SITLife-v\d+\.\d+\.\d+\+\d+' | head -n 1 | cut -d'-' -f2) >> "$GITHUB_OUTPUT"
+          echo "PREVIOUS_TAG="$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r '.tag_name') >> "$GITHUB_OUTPUT"
+      
+      - name: Check builds
+        id: builds
+        env:
+          RESOLVED_VERSION: ${{ steps.get_git_info.outputs.RESOLVED_VERSION }}
+        run: |
+          if [ ! -f "new-build-artifacts/SITLife-${{ env.RESOLVED_VERSION }}.apk" ]; then
+            echo "APK_SHA256=" >> "$GITHUB_OUTPUT"
+          else
+            echo "APK_SHA256=- \`SITLife-${{ env.RESOLVED_VERSION }}.apk\`: "$(sha256sum new-build-artifacts/SITLife-${{ env.RESOLVED_VERSION }}.apk | awk '{print $1}') >> "$GITHUB_OUTPUT"
+          fi
+          if [ ! -f "new-build-artifacts/SITLife-${{ env.RESOLVED_VERSION }}.ipa" ]; then
+            echo "IPA_SHA256=" >> "$GITHUB_OUTPUT"
+          else
+            echo "IPA_SHA256=- \`SITLife-${{ env.RESOLVED_VERSION }}.ipa\`: "$(sha256sum new-build-artifacts/SITLife-${{ env.RESOLVED_VERSION }}.ipa | awk '{print $1}') >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        env:
+            RESOLVED_VERSION: ${{ steps.get_git_info.outputs.RESOLVED_VERSION }}
+            PREVIOUS_TAG: ${{ steps.get_git_info.outputs.PREVIOUS_TAG }}
+        with:
+          files: |
+            new-build-artifacts/SITLife-${{ env.RESOLVED_VERSION }}.apk
+            new-build-artifacts/SITLife-${{ env.RESOLVED_VERSION }}.ipa
+          tag_name: ${{ env.RESOLVED_VERSION }}
+          body: |
+              ## Changes
+              ### Features
+                - Foo
+              ### Bug fixes
+                - Bar
+
+              ## 更改
+              ### 新功能
+                - Foo
+              ### Bug 修复
+                - Bar
+
+              ## How to download
+                <!-- Android:main -->
+                <!-- - `Android`: Click the .apk files below.-->
+                <!-- iOS:main -->
+                <!-- - `iOS`: [Download on the App Store](https://apps.apple.com/cn/app/id6468989112).-->
+                <!-- iOS:TestFlight -->
+                <!-- - `iOS`: [Join the Test Flight](https://testflight.apple.com/join/ecafeulK).-->
+                <!-- iOS:Debug -->
+                <!-- - `iOS`: Click the .ipa files below.-->
+
+                - `Android`: Click the .apk files below.
+                - `iOS`: [Download on the App Store](https://apps.apple.com/cn/app/id6468989112).
+
+              ## Checksum (sha256)
+              ${{ steps.builds.outputs.APK_SHA256 }}
+              ${{ steps.builds.outputs.IPA_SHA256 }}
+
+              Full Changelog: https://github.com/${{ github.repository }}/compare/${{ env.PREVIOUS_TAG }}...${{ env.RESOLVED_VERSION }}
+          draft: true
+          prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release new version
+name: 3.Release New Version
 
 on:
   release:


### PR DESCRIPTION
本次对工作流中的构建与发布进行分离。
构建时，仅单独运行`Flutter Build`即可。发布时，仅单独运行`Draft New Release`即可。

需注意，发布工作流仅读取最新一次build工作流的构建和相关数据，无法指定以往的某个版本。
